### PR TITLE
perf - reduce number of calls to JObject.FromObject using Lazy

### DIFF
--- a/lib/Authorization/Client/ClientContext.cs
+++ b/lib/Authorization/Client/ClientContext.cs
@@ -8,7 +8,7 @@ namespace AuthZyin.Authorization.Client
     /// Class representing context data to send to the client for client authorization.
     /// </summary>
     /// <typeparam name="T">Custom data type</typeparam>
-    public class ClientContext<T> where T : class
+    public class ClientContext
     {
         /// <summary>
         /// Gets the user context, which will also be sent to client
@@ -24,13 +24,13 @@ namespace AuthZyin.Authorization.Client
         /// <summary>
         /// Gets or sets custom data used to do "resource" based authorization on client. It's of type T.
         /// </summary>
-        public T Data { get; set; }
+        public object Data { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the ClientContext class to send to client
         /// </summary>
         /// <param name="context">AuthZyin context</param>
-        public ClientContext(AuthZyinContext<T> context)
+        public ClientContext(IAuthZyinContext context)
         {
             if (context == null)
             {
@@ -39,7 +39,7 @@ namespace AuthZyin.Authorization.Client
 
             this.UserContext = context.UserContext;
             this.Policies = context.Policies.Select(x => new ClientPolicy(x.name, x.policy)).ToList();
-            this.Data = context.Data;
+            this.Data = context.GetData();
         }
     }
 }

--- a/lib/Authorization/Client/ClientPolicy.cs
+++ b/lib/Authorization/Client/ClientPolicy.cs
@@ -23,8 +23,8 @@ namespace AuthZyin.Authorization.Client
         public string Name { get; }
 
         /// <summary>
-        /// Gets or sets the requirement list. In fact all requirements to send to client should be of type AbstractRequirement.
         /// TODO[sidecus]: Workaround for new System.Text.Json serialization
+        /// Gets or sets the requirement list. In fact all requirements to send to client should be inherited from type Requirement.
         /// The reason to use List<object> instead of List<AbstractRequirement> as the item type is to force System.Text.Json
         /// to serialize all members in web api response.
         /// https://github.com/dotnet/runtime/issues/31742 & https://github.com/dotnet/runtime/issues/29937

--- a/lib/Authorization/Resource.cs
+++ b/lib/Authorization/Resource.cs
@@ -1,22 +1,46 @@
 namespace AuthZyin.Authorization
 {
+    using System;
+    using Newtonsoft.Json.Linq;
+
     /// <summary>
     /// Authorization resource base class
     /// </summary>
     public abstract class Resource
     {
+        /// <summary>
+        /// Lazy version of the JObject prepresentation of the current resource object
+        /// </summary>
+        protected Lazy<JObject> lazyJObject;
+
+        /// <summary>
+        /// Initializes a new instance of the Resource class.
+        /// </summary>
+        public Resource()
+        {
+            this.lazyJObject = new Lazy<JObject>(() => JObject.FromObject(this));
+        }
+
+        /// <summary>
+        /// Get the current resource as a JObject
+        /// </summary>
+        /// <returns>JObject version of the current resource</returns>
+        public JObject GetResourceAsJObject()
+        {
+            return this.lazyJObject.Value;
+        }
     }
 
     /// <summary>
     /// Resource type to handle constant processing in requirement instead of real resource
     /// </summary>
     /// <typeparam name="T">constant type</typeparam>
-    public sealed class ConstantWrapperResource<T> : Resource
+    public sealed class ValueWrapperResource<T> : Resource
     {
         /// <summary>
         /// JsonPath to the value member
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Json path to get the value</returns>
         public static readonly string ValueJsonPath = $"$.{nameof(Value)}";
 
         /// <summary>
@@ -27,7 +51,7 @@ namespace AuthZyin.Authorization
         /// <summary>
         /// Initializes a new instance of <see cref="ConstantWrapperResource" /> the class
         /// </summary>
-        public ConstantWrapperResource(T value)
+        public ValueWrapperResource(T value)
         {
             this.Value = value;
         }

--- a/lib/Controller/AuthZyinController.cs
+++ b/lib/Controller/AuthZyinController.cs
@@ -3,6 +3,7 @@ namespace AuthZyin.Controller
     using System;
     using System.Threading.Tasks;
     using AuthZyin.Authorization;
+    using AuthZyin.Authorization.Client;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
@@ -38,7 +39,7 @@ namespace AuthZyin.Controller
         [Route("context")]
         public async Task<IActionResult> GetPolicies()
         {
-            var data = await Task.FromResult(this.authZyinContext.ClientContext);
+            var data = await Task.FromResult(new ClientContext(this.authZyinContext));
             return this.Ok(data);
         }
     }

--- a/sample/AuthN/SampleAuthZyinContext.cs
+++ b/sample/AuthN/SampleAuthZyinContext.cs
@@ -1,7 +1,5 @@
 namespace sample.AuthN
 {
-    using System;
-    using System.Text.Json;
     using AuthZyin.Authorization;
     using Microsoft.AspNetCore.Http;
 
@@ -11,20 +9,6 @@ namespace sample.AuthN
     public class SampleAuthZyinContext : AuthZyinContext<AuthorizationData>
     {
         /// <summary>
-        // Implements the custom data factory.
-        // You can derive your own AuthZyinContext and use more dependencies
-        // to produce the factory method.
-        /// </summary>
-        /// <returns>a factory method which generates the required custom data</returns>
-        protected override Func<AuthorizationData> dataFactory => () =>
-        {
-            // Retrieves the custom data json string from claims (if any).
-            // It's denoted by a virtual member CustomClaimTypeToProcess.
-            var claim = this.claimsAccessor.GetClaim(AuthorizationData.ClaimType);
-            return AuthorizationData.FromClaim(claim);
-        };
-
-        /// <summary>
         /// Initializes a new instance of the SampleAuthZyinContext class
         /// </summary>
         /// <param name="policyList">policy list</param>
@@ -32,6 +16,18 @@ namespace sample.AuthN
         public SampleAuthZyinContext(IAuthorizationPolicyList policyList, IHttpContextAccessor contextAccessor)
             : base(policyList, contextAccessor)
         {
+        }
+
+        /// <summary>
+        // Creates our own authorization data
+        /// </summary>
+        /// <returns>the authorization data object</returns>
+        protected override AuthorizationData CreateData()
+        {
+            // Retrieves the custom data json string from claims (if any).
+            // It's denoted by a virtual member CustomClaimTypeToProcess.
+            var claim = this.claimsAccessor.GetClaim(AuthorizationData.ClaimType);
+            return AuthorizationData.FromClaim(claim);
         }
     }
 }

--- a/test/AuthZyinContextTest.cs
+++ b/test/AuthZyinContextTest.cs
@@ -2,12 +2,12 @@ namespace test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Security.Claims;
     using AuthZyin.Authorization;
-    using AuthZyin.Authorization.Client;
     using Microsoft.AspNetCore.Authorization;
     using Xunit;
+    using Moq;
+    using Moq.Protected;
 
     public class AuthZyinContextTest
     {
@@ -24,42 +24,63 @@ namespace test
         [Fact]
         public void UserContextAndPoliciesAreConstructedCorrectly()
         {
-            var userId = Guid.NewGuid().ToString();
-            var userName = "testusre";
-            var roles = new string[] { "role1", "role2" };
-            var testCustomData = new TestCustomData
-            {
-                IntValue = 234226546,
-            };
-            var policyBuilder = new AuthorizationPolicyBuilder();
-            roles.ToList().ForEach(r => policyBuilder.RequireRole(r));
+            // Use TestContext proxy as the concrete type
+            var context = new TestContext() as AuthZyinContext<TestCustomData>;
 
-            var policies = new List<(string name, AuthorizationPolicy policy)>
-            {
-                ("rquiresRolePolicy", policyBuilder.Build()),
-            };
-
-            var context = TestContext.CreateTestContext(
-                userId,
-                userName,
-                roles,
-                policies,
-                testCustomData);
+            // Make sure Test context is inherited from AuthZyinContext
+            Assert.NotNull(context);
                 
-            Assert.Same(context.Policies, policies);
+            Assert.Same(context.Policies, TestContext.DefaultPolicies);
             Assert.NotNull(context.UserContext);
-            Assert.Same(context.UserContext.UserId, userId);
-            Assert.Same(context.UserContext.UserName, userName);
+            Assert.Same(context.UserContext.UserId, TestContext.DefaultUserId);
+            Assert.Same(context.UserContext.UserName, TestContext.DefaultUserName);
 
-            // Make sure custom data factory is used
-            Assert.NotNull(context.Data);
-            Assert.Same(context.Data, testCustomData);
+            // Make sure data is constructed and returned from both the getter and the GetData method
+            var data = context.Data;
+            Assert.NotNull(data);
+            Assert.True(data is TestCustomData);
+            Assert.Same(data, context.GetData());
 
-            // Check client context generation
-            var clientContext = context.ClientContext as ClientContext<TestCustomData>;
-            Assert.NotNull(clientContext);
-            Assert.Same(clientContext.UserContext, context.UserContext);
-            Assert.Same(clientContext.Data, context.Data);
+            // Make sure the result JObject data is correct
+            var dataJObj = context.GetDataAsJObject();
+            var dataConverted = dataJObj.ToObject<TestCustomData>();
+            Assert.NotSame(data, dataConverted);
+            Assert.Equal(data.IntValue, dataConverted.IntValue);
+            Assert.Equal(data.StringValue, dataConverted.StringValue);
+            Assert.Equal(data.BiggerIntValue, dataConverted.BiggerIntValue);
+            Assert.Equal(data.ArrayValue[0], dataConverted.ArrayValue[0]);
+            Assert.Equal(data.DateValue, dataConverted.DateValue);
+        }
+
+        [Fact]
+        public void VerifyLazyMembersAreLazy()
+        {
+            // Mock a inherited class instance of AuthZyinContext<TestCustomData>
+            var mockContext = new Mock<AuthZyinContext<TestCustomData>>(TestContext.DefaultPolicies, TestContext.DefaultClaimsPrincipal)
+            {
+                CallBase = true,
+            };
+
+            var data = new TestCustomData();
+            mockContext.Protected().Setup<TestCustomData>("CreateData").Returns(data);
+            var context = mockContext.Object;
+
+            // Accessing data multiple times only triggers the CreateData method once
+            var data1 = context.Data;
+            mockContext.Protected().Verify("CreateData", Times.Once());
+            var data2 = context.Data;
+            mockContext.Protected().Verify("CreateData", Times.Once());
+            Assert.Same(data1, data2);
+            var data3 = context.GetData();
+            mockContext.Protected().Verify("CreateData", Times.Once());
+            Assert.Same(data1, data3);
+
+            // Accessing GetDataAsJObject doesn't cause multiple JObject constructs
+            var jObj1 = context.GetDataAsJObject();
+            Assert.NotNull(jObj1);
+            mockContext.Protected().Verify("CreateData", Times.Once());
+            var jObj2 = context.GetDataAsJObject();
+            Assert.Same(jObj1, jObj2);
         }
     }
 }

--- a/test/AuthZyinHandlerTest.cs
+++ b/test/AuthZyinHandlerTest.cs
@@ -1,7 +1,6 @@
 namespace test
 {
     using System;
-    using System.Linq;
     using System.Security.Claims;
     using System.Threading.Tasks;
     using AuthZyin.Authorization;
@@ -12,7 +11,7 @@ namespace test
 
     public class AuthZyinHandlerTest
     {
-        private readonly AuthZyinContext<TestCustomData> context = TestContext.CreateDefaultTestContext();
+        private readonly AuthZyinContext<TestCustomData> context = new TestContext();
         private readonly ILogger<AuthZyinHandler> logger = TestLoggerFactory.CreateLogger<AuthZyinHandler>();
 
         [Fact]

--- a/test/ClientContextTest.cs
+++ b/test/ClientContextTest.cs
@@ -12,14 +12,14 @@ namespace test
         [Fact]
         public void ConstructorThrowsOnInvalidArg()
         {
-            Assert.Throws<ArgumentNullException>(() => new ClientContext<TestCustomData>(null));
+            Assert.Throws<ArgumentNullException>(() => new ClientContext(null));
         }
 
         [Fact]
         public void UserContextAndPoliciesAreConstructedCorrectly()
         {
-            var context = TestContext.CreateDefaultTestContext();
-            var clientContext = new ClientContext<TestCustomData>(context);
+            var context = new TestContext();
+            var clientContext = new ClientContext(context);
 
             // Check client context generation
             Assert.Same(clientContext.UserContext, context.UserContext);

--- a/test/ConcreteRequirementsTest.cs
+++ b/test/ConcreteRequirementsTest.cs
@@ -45,7 +45,7 @@ namespace test
         [MemberData(nameof(ConcreteRequirementsTestCases))]
         public void TestConcreteRequirements(Requirement requirement, bool expectedResult)
         {
-            var context = TestContext.CreateDefaultTestContext();
+            var context = new TestContext();
             Assert.Equal(expectedResult, requirement.Evaluate(context, MyResource));
         }
     }

--- a/test/JsonPathConstantRequirementTest.cs
+++ b/test/JsonPathConstantRequirementTest.cs
@@ -92,7 +92,7 @@ namespace test
             var requirement = Activator.CreateInstance(constRequirementType, operatorType, contextPath, constValue);
 
             Assert.Equal(contextPath, this.GetPropertyValue(constRequirementType, "DataJPath", requirement));
-            Assert.Equal(ConstantWrapperResource<int>.ValueJsonPath, this.GetPropertyValue(constRequirementType, "ResourceJPath", requirement));
+            Assert.Equal(ValueWrapperResource<int>.ValueJsonPath, this.GetPropertyValue(constRequirementType, "ResourceJPath", requirement));
             Assert.Equal(operatorType, this.GetPropertyValue(constRequirementType, "Operator", requirement));
             Assert.Equal(Direction.ContextToResource, this.GetPropertyValue(constRequirementType, "Direction", requirement));
             Assert.Equal(constValue, this.GetPropertyValue(constRequirementType, "ConstValue", requirement));
@@ -106,7 +106,7 @@ namespace test
             object constValue,
             bool expectedReseult)
         {
-            var authZyinContext = TestContext.CreateDefaultTestContext();
+            var authZyinContext = new TestContext();
 
             var genericType = typeof(JsonPathConstantRequirement<,>);
             var constType = constValue != null ? constValue.GetType() : typeof(string);             //special case for null value and defaul the type to string
@@ -125,14 +125,6 @@ namespace test
                 Assert.Equal(expectedReseult, (bool)evaluateMethod.Invoke(requirement, new object[] { authZyinContext, null as Resource }));
                 Assert.Equal(expectedReseult, (bool)evaluateMethod.Invoke(requirement, new object[] { authZyinContext, new TestResourceInvalid() }));
             }
-        }
-
-        [Fact]
-        public void ConstantWrapperResourceValueJsonPath()
-        {
-            // Ensure the wrapper resource use a member named "Value" to save the constant right operand.
-            // It's needed since the client is betting it to be harded coded to "$.Value".
-            Assert.Equal("$.Value", ConstantWrapperResource<int>.ValueJsonPath);
         }
 
         private object GetPropertyValue(Type type, string memberName, object target)

--- a/test/JsonPathRequirementTest.cs
+++ b/test/JsonPathRequirementTest.cs
@@ -7,34 +7,30 @@ namespace test
 
     public class JsonPathRequirementTest
     {
-        [Fact]
-        public void ConsructorThrowsOnInvalidArg()
+        private static readonly TestResource TestResource = new TestResource();
+        public static readonly object[][] ConstrucNegativeCases = new []
         {
-            var resource = new TestResource();
+            new object[] { OperatorType.Invalid, string.Empty, string.Empty, Direction.ContextToResource },
+            new object[] { OperatorType.Or, "$", string.Empty, Direction.ContextToResource },
+            new object[] { OperatorType.GreaterThan, null, TestResource.JPathIntValue, Direction.ContextToResource },
+            new object[] { OperatorType.RequiresRole, "abc", null, Direction.ResourceToContext },
+            new object[] { OperatorType.RequiresRole, "abc", "dcd", (Direction) 0 },
+        };
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonPathRequirement<TestCustomData, TestResource>(
-                OperatorType.Invalid,
-                "",
-                "",
-                Direction.ContextToResource));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonPathRequirement<TestCustomData, TestResource>(
-                OperatorType.Or,
-                "$",
-                "",
-                Direction.ContextToResource));
-
-            Assert.Throws<ArgumentNullException>(() => new JsonPathRequirement<TestCustomData, TestResource>(
-                OperatorType.GreaterThan,
-                null,
-                resource.JPathIntValue,
-                Direction.ContextToResource));
-
-            Assert.Throws<ArgumentNullException>(() => new JsonPathRequirement<TestCustomData, TestResource>(
-                OperatorType.RequiresRole,
-                "abc",
-                null,
-                Direction.ContextToResource));
+        [Theory]
+        [MemberData(nameof(ConstrucNegativeCases))]
+        public void ConsructorThrowsOnInvalidArg(
+            OperatorType operatorType,
+            string dataPath,
+            string resourcePath,
+            Direction direction
+        )
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new JsonPathRequirement<TestCustomData, TestResource>(
+                operatorType,
+                dataPath,
+                resourcePath,
+                direction));
         }
         
         [Fact]
@@ -42,7 +38,7 @@ namespace test
         {
             var dataJPathIntValue = new TestCustomData().JPathIntValue;
 
-            var context = TestContext.CreateDefaultTestContext(setNullCustomData: true);
+            var context = new TestContext(setNullCustomData: true);
             var resource = new TestResource();
 
             var equalsRequirement = new JsonPathRequirement<TestCustomData, TestResource>(
@@ -58,7 +54,7 @@ namespace test
         [Fact]
         public void JsonPathRequirementPositiveBehavior()
         {
-            var context = TestContext.CreateDefaultTestContext();
+            var context = new TestContext();
             var resource = new TestResource();
 
             var greaterThanRequirement = new JsonPathRequirement<TestCustomData, TestResource>(

--- a/test/ResourceTest.cs
+++ b/test/ResourceTest.cs
@@ -1,0 +1,33 @@
+namespace  test
+{
+    using Xunit;
+    using AuthZyin.Authorization;
+
+    public class ResourceTest
+    {
+        [Fact]
+        public void ResourceJObjectBehavior()
+        {
+            var resource = new ValueWrapperResource<int>(5);
+
+            var jObj1 = resource.GetResourceAsJObject();
+            var jObj2 = resource.GetResourceAsJObject();
+
+            // Make sure we don't do JObject conversion twice
+            Assert.Same(jObj1, jObj2);
+            Assert.Equal(5, resource.Value);
+
+            // Make sure data is correct
+            var convertedBack = jObj1.ToObject<ValueWrapperResource<int>>();
+            Assert.Equal(5, convertedBack.Value);
+        }
+
+        [Fact]
+        public void ConstantWrapperResourceValueJsonPath()
+        {
+            // Ensure the wrapper resource use a member named "Value" to save the constant right operand.
+            // It's needed since the client is betting it to be harded coded to "$.Value".
+            Assert.Equal("$.Value", ValueWrapperResource<int>.ValueJsonPath);
+        }
+    }
+}

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="moq" Version="4.14.3" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/tye.yaml
+++ b/tye.yaml
@@ -6,7 +6,7 @@
 #
 name: authzyin
 services:
-- name: sample
+- name: authzyin_sample
   project: sample/sample.csproj
   bindings:
   - port: 5001


### PR DESCRIPTION
Reduce number of calls to JObject.FromObject for both the context object and the resource object.
Previously they'll be called upon each requirement evluation. Now they are called only once per object instance.

This also means that you should **make your derived AuthZyinContext and Resource classes as "immutable" objects**.