### PR TITLE
add skipspa to enable server only docker image

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,10 +19,7 @@ jobs:
         dotnet-version: 3.1.101
     - name: Install dependencies
       run: dotnet restore
-    - name: Build
+    - name: Build lib and sample including SPA
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
-    # publish will trigger ClientApp SPA building
-    - name: Publish (with SPA)
-      run: dotnet publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# build image
+# build stage
 #
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
@@ -13,13 +13,15 @@ COPY test/test.csproj test/
 RUN dotnet restore
 
 # copy everything else and build app
+# we are skiping SPA in this image. SPA is handled by a different docker image with nginx.
+# check sample.csproj for how SkipSPA is defined.
 COPY lib/ lib/
 COPY sample/ sample/
 WORKDIR /authzyin/sample
-RUN dotnet publish -c Release
+RUN dotnet publish -c Release /p:SkipSPA=true
 
 #
-# runtime image
+# runtime stage
 #
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine

--- a/sample/ClientApp/Dockerfile
+++ b/sample/ClientApp/Dockerfile
@@ -1,13 +1,12 @@
 #
-# build image
+# build stage
 #
 
 FROM node:lts-alpine3.9 as build
 WORKDIR /usr/app
 
 # copy package and yarn install as a distinct layer
-COPY package.json ./
-COPY yarn.lock ./
+COPY package.json yarn.lock ./
 RUN yarn install
 
 # copy everything else and build
@@ -15,7 +14,7 @@ COPY ./ ./
 RUN yarn build
 
 #
-# runtime image
+# runtime stage
 #
 
 FROM nginx:alpine as runtime

--- a/sample/sample.csproj
+++ b/sample/sample.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\lib\lib.csproj" />
   </ItemGroup>
-  <Target Name="DebugEnsureNodeAndYarn" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
+  <Target Name="EnsureNodeAndYarn" BeforeTargets="Build" Condition=" !Exists('$(SpaRoot)node_modules') And '$(SkipSPA)' != 'true' ">
     <!-- Ensure Node.js and yarn are installed -->
     <Exec Command="node --version" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
@@ -36,8 +36,13 @@
     <Message Importance="high" Text="Restoring dependencies for SPA, this might take sveral minutes..." />
     <Exec WorkingDirectory="$(SpaRoot)" Command="yarn install" />
   </Target>
-  <!-- Disabling SPA publish in release. We use docker to build them into two different images instead. -->
-  <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish" Condition="'$(Configuration)' == 'Debug'">
+  <Target Name="BuildSPA" AfterTargets="Build" Condition=" '$(Configuration)' != 'Debug' And '$(SkipSPA)' != 'true' ">
+    <!-- build spa app for non debug when SkipSPA is not specified. Debug build will bulid the spa during run time usin the spa middleware -->
+    <Message Importance="high" Text="Building SPA ClientApp..." />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="yarn build" />
+  </Target>
+  <!-- Publish SPA. We will skip this when SkipSPA option is specified. -->
+  <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish" Condition=" '$(SkipSPA)' != 'true' ">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
     <Exec WorkingDirectory="$(SpaRoot)" Command="yarn install" />
     <Exec WorkingDirectory="$(SpaRoot)" Command="yarn build" />


### PR DESCRIPTION
Added SkipSPA option to dotnet build and publish.
For docker we are using two images using nginx-ingress: a server image containing the .net core server part including pages, a client image containing the SPA only which is served via nginx direclty. 

With this option:
Normal builds including github actions will include SPA.
Docker server build (via the docker file in the root folder) will skip SPA build and publish.